### PR TITLE
Make nginx-lb tpl dynamic, fixup missing etcd SRV records

### DIFF
--- a/terraform/.terraform.tfstate.lock.info
+++ b/terraform/.terraform.tfstate.lock.info
@@ -1,0 +1,1 @@
+{"ID":"fac837cb-5d0e-d5c8-dbef-9dadf31e6c75","Operation":"OperationTypeApply","Info":"","Who":"root@lab.gxr.me","Version":"0.12.20","Created":"2020-05-25T02:11:04.93821675Z","Path":"terraform.tfstate"}

--- a/terraform/3_bootstrap.tf
+++ b/terraform/3_bootstrap.tf
@@ -4,6 +4,8 @@ module "bootstrap_openshift" {
   cluster_name         = var.cluster_name
   cluster_basedomain   = var.cluster_basedomain
   node_count           = 1
+  count_compute        = var.count_compute
+  count_master         = var.count_master
   plan                 = var.plan_master
   facility             = var.facility
   ssh_private_key_path = var.ssh_private_key_path

--- a/terraform/modules/bootstrap/templates/nginx-lb.conf.tpl.backup
+++ b/terraform/modules/bootstrap/templates/nginx-lb.conf.tpl.backup
@@ -1,7 +1,9 @@
 stream {
     upstream backend_api {
         server bootstrap-0.${cluster_name}.${cluster_basedomain}:6443;
-${expanded_masters}
+        %{ for i in c_m ~}
+        server master-${i}.${cluster_name}.${cluster_basedomain}:6443;
+        %{ endfor }
     }
 
     server {
@@ -11,7 +13,9 @@ ${expanded_masters}
 
     upstream backend_mcs {
         server bootstrap-0.${cluster_name}.${cluster_basedomain}:22623;
-${expanded_mcs}
+        %{ for i in count_master ~}
+        server master-${i}.${cluster_name}.${cluster_basedomain}:22623;
+        %{ endfor }
     }
 
     server {
@@ -20,7 +24,9 @@ ${expanded_mcs}
     }
 
     upstream backend_https {
-${expanded_compute}
+        %{ for i in count_compute ~}
+        server worker-${i}.${cluster_name}.${cluster_basedomain}:443;
+        %{ endfor }
     }
 
     server {

--- a/terraform/modules/node/main.tf
+++ b/terraform/modules/node/main.tf
@@ -36,6 +36,32 @@ resource "cloudflare_record" "dns_a_node" {
   count      = "${var.node_count}"
 }
 
+resource "cloudflare_record" "dns_a_etcd" {
+  zone_id    = "${var.cf_zone_id}"
+  type       = "A"
+  name       = "etcd-${count.index}.${var.cluster_name}.${var.cluster_basedomain}"
+  value      = "${packet_device.node[count.index].access_public_ipv4}"
+  count      = (var.node_type == "master" ? var.node_count : 0 )
+}
+
+resource "cloudflare_record" "dns_srv_etcd" {
+  zone_id    = "${var.cf_zone_id}"
+  type       = "SRV"
+  name       = "_etcd-server-ssl._tcp"
+  count      = (var.node_type == "master" ? var.node_count : 0 )
+
+  data = {
+    service  = "_etcd-server-ssl"
+    proto    = "_tcp"
+    name     = "${var.cluster_name}.${var.cluster_basedomain}"
+    priority = 0
+    weight   = 10
+    port     = 2380
+    target   = "etcd-${count.index}.${var.cluster_name}.${var.cluster_basedomain}"
+  }
+
+}
+
 output "finished" {
   value      = "Provisioning node type ${var.node_type} finished."
 }


### PR DESCRIPTION
resolves #8 and improves nginx-lb generation to use counts from vars